### PR TITLE
fix download link to binary file

### DIFF
--- a/install.js
+++ b/install.js
@@ -21,7 +21,7 @@ var url = require('url')
 var util = require('util')
 var which = require('which')
 
-var downloadUrl = 'http://download.slimerjs.org/v0.9/'+ helper.version +'/slimerjs-'+ helper.version +'-'
+var downloadUrl = 'http://download.slimerjs.org/releases/'+ helper.version +'/slimerjs-'+ helper.version +'-'
 
 var originalPath = process.env.PATH
 
@@ -116,10 +116,10 @@ whichDeferred.promise
         path.join(pkgPath, 'slimerjs')
     var relativeLocation = path.relative(libPath, location)
     writeLocationFile(relativeLocation)
-    
+
     // Ensure executable is executable by all users
     fs.chmodSync(location, '755')
-    
+
     console.log('Done. Slimerjs binary available at', location)
     exit(0)
   })


### PR DESCRIPTION
updated the link and it seems to work now :)

Darwin 2 kaizhu@minikai:~/src/slimerjs $ node install.js
Downloading http://download.slimerjs.org/releases/0.9.1/slimerjs-0.9.1-mac.tar.bz2
Saving to /var/folders/h4/pg57cdtx2yq3tn0mww9tkjpc0000gp/T/slimerjs/slimerjs-0.9.1-mac.tar.bz2
Receiving...
Received 782K...
Received 1564K...
Received 2346K...
Received 3129K...
Received 3911K..

Received 39395K...
Received 39399K total.
Extracting tar contents (via spawned process)
Copying extracted folder /var/folders/h4/pg57cdtx2yq3tn0mww9tkjpc0000gp/T/slimerjs/slimerjs-0.9.1-mac.tar.bz2-extract-1401971251343/slimerjs-0.9.1 -> /Users/kaizhu/src/slimerjs/lib/slimer
Writing location.js file
Done. Slimerjs binary available at /Users/kaizhu/src/slimerjs/lib/slimer/slimerjs
Darwin 2 kaizhu@minikai:~/src/slimerjs $ 
