### PR TITLE
Bump slimerjs version to 0.9.6

### DIFF
--- a/lib/slimerjs.js
+++ b/lib/slimerjs.js
@@ -26,7 +26,7 @@ try {
  * The version of slimerjs installed by this package.
  * @type {number}
  */
-exports.version = '0.9.5'
+exports.version = '0.9.6'
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slimerjs",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "keywords": [
     "slimerjs",
     "headless",


### PR DESCRIPTION
[0.9.6](https://docs.slimerjs.org/0.9/release-notes.html#version-0-9-6) was released on June 8th.