### PR TITLE
Fix windows and mac download URLs

### DIFF
--- a/install.js
+++ b/install.js
@@ -343,9 +343,9 @@ function getDownloadUrl() {
   } else if (process.platform === 'linux' && process.arch == 'ia32') {
     downloadUrl += 'linux-i686.tar.bz2'
   } else if (process.platform === 'darwin' || process.platform === 'openbsd' || process.platform === 'freebsd') {
-    downloadUrl += 'macosx.zip'
+    downloadUrl += 'mac.tar.bz2'
   } else if (process.platform === 'win32') {
-    downloadUrl += 'windows.zip'
+    downloadUrl += 'win32.zip'
   } else {
     return null
   }


### PR DESCRIPTION
The download filenames in install.js don't match the actual file locations.
Should fix #29 