### PR TITLE
Sync "cdn_url" support with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,18 +87,18 @@ a download mirror. To set a mirror, set npm config property `slimerjs_cdnurl`.
 Default is ``.
 
 ```shell
-npm install slimerjs --slimerjs_cdnurl=https://cnpmjs.org/downloads
+npm install slimerjs --slimerjs_cdnurl=https://download.slimerjs.org/releases
 ```
 
 Or add property into your `.npmrc` file (https://www.npmjs.org/doc/files/npmrc.html)
 
 ```
-slimerjs_cdnurl=https://cnpmjs.org/downloads
+slimerjs_cdnurl=https://download.slimerjs.org/releases
 ```
 
 Another option is to use PATH variable `SLIMERJS_CDNURL`.
 ```shell
-SLIMERJS_CDNURL=https://cnpmjs.org/downloads npm install phantomjs
+SLIMERJS_CDNURL=https://download.slimerjs.org/releases npm install slimerjs
 ```
 
 ##### Using SlimerJS from disk

--- a/install.js
+++ b/install.js
@@ -335,8 +335,8 @@ function trySlimerjsOnPath() {
 function getDownloadUrl() {
   var cdnUrl = process.env.npm_config_slimerjs_cdnurl ||
       process.env.SLIMERJS_CDNURL ||
-      'https://download.slimerjs.org/releases/'
-  var downloadUrl = cdnUrl + helper.version +'/slimerjs-'+ helper.version +'-'
+      'https://download.slimerjs.org/releases'
+  var downloadUrl = cdnUrl + '/' + helper.version +'/slimerjs-'+ helper.version +'-'
 
   if (process.platform === 'linux' && process.arch === 'x64') {
     downloadUrl += 'linux-x86_64.tar.bz2'


### PR DESCRIPTION
Before that change a overwritten `SLIMERJS_CDNURL` had to include a "/" at the end of the string value in order to create valid and working URL strings. That didn't match the documentation (and the logic in the Medium/phantomjs project).