### PR TITLE
Loosen request dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "hasha": "^2.2.0",
     "kew": "~0.7.0",
     "progress": "~1.1.8",
-    "request": "~2.67.0",
+    "request": "^2.67.0",
     "request-progress": "~2.0.1",
     "which": "~1.2.2"
   },


### PR DESCRIPTION
Currently installing this module via npm gives:
```
npm WARN deprecated tough-cookie@2.2.2: ReDoS vulnerability parsing Set-Cookie https://nodesecurity.io/advisories/130
```

Because of the older request dependency